### PR TITLE
Enhance deployment updates for existing configurations when 'apigee.apihub.config.options=update' is used

### DIFF
--- a/src/main/java/com/apigee/apihub/config/mavenplugin/DeploymentsMojo.java
+++ b/src/main/java/com/apigee/apihub/config/mavenplugin/DeploymentsMojo.java
@@ -330,6 +330,10 @@ public class DeploymentsMojo extends ApiHubAbstractMojo {
 		try {
 			apiHubClient = ApiHubClientSingleton.getInstance(profile).getApiHubClient();
 			com.google.cloud.apihub.v1.Deployment deploymentObj = ProtoJsonUtil.fromJson(deploymentStr, com.google.cloud.apihub.v1.Deployment.class);
+			if (deploymentObj != null) {
+				String deploymentName = PluginUtils.replacer(deploymentObj.getName(), PluginConstants.PATTERN1, format("projects/%s/locations/%s", buildProfile.getProjectId(), buildProfile.getLocation()));
+				deploymentObj = com.google.cloud.apihub.v1.Deployment.newBuilder(deploymentObj).setName(deploymentName).build();
+			}
 			List<String> fieldMaskValues = new ArrayList<>();
 			fieldMaskValues.add("display_name");
 			fieldMaskValues.add("description");


### PR DESCRIPTION
This pull request addresses an issue where the deployment process fails with the apigee.apihub.config.options=update option when the deployment already exists.

**Cause**
The issue arises because the deployment.json file contains a deployment name in the format:
"name":"projects/PROJECT_ID/locations/LOCATION/deployments/deployment1"

Replacing this name just before calling the API seemed like a good approach but proved incompatible with the deployment update process.

**Solution**
This PR ensures proper handling of the deployment name during updates, avoiding the failure.

Here is a stack trace for reference: 

```
************************************************************************
API Hub Deployments
************************************************************************
Fetching deployments.json file from ./ directory
Checking if Deployment - deployment1 exist
Deployment "deployment1" already exists. Updating.
com.google.api.gax.rpc.PermissionDeniedException: Forbidden
        at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:58)
        at com.google.api.gax.httpjson.HttpJsonApiExceptionFactory.createApiException(HttpJsonApiExceptionFactory.java:76)
        at com.google.api.gax.httpjson.HttpJsonApiExceptionFactory.create(HttpJsonApiExceptionFactory.java:54)
        at com.google.api.gax.httpjson.HttpJsonExceptionCallable$ExceptionTransformingFuture.onFailure(HttpJsonExceptionCallable.java:97)
        at com.google.api.core.ApiFutures$1.onFailure(ApiFutures.java:84)
        at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1095)
        at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
        at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1300)
        at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1061)
        at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:811)
        at com.google.api.core.AbstractApiFuture$InternalSettableFuture.setException(AbstractApiFuture.java:92)
        at com.google.api.core.AbstractApiFuture.setException(AbstractApiFuture.java:74)
        at com.google.api.gax.httpjson.HttpJsonClientCalls$HttpJsonFuture.setException(HttpJsonClientCalls.java:133)
        at com.google.api.gax.httpjson.HttpJsonClientCalls$FutureListener.onClose(HttpJsonClientCalls.java:167)
        at com.google.api.gax.httpjson.HttpJsonClientCallImpl$OnCloseNotificationTask.call(HttpJsonClientCallImpl.java:551)
        at com.google.api.gax.httpjson.HttpJsonClientCallImpl.notifyListeners(HttpJsonClientCallImpl.java:390)
        at com.google.api.gax.httpjson.HttpJsonClientCallImpl.deliver(HttpJsonClientCallImpl.java:317)
        at com.google.api.gax.httpjson.HttpJsonClientCallImpl.setResult(HttpJsonClientCallImpl.java:163)
        at com.google.api.gax.httpjson.HttpRequestRunnable.run(HttpRequestRunnable.java:148)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
        Suppressed: com.google.api.gax.rpc.AsyncTaskException: Asynchronous task failed
                at com.google.api.gax.rpc.ApiExceptions.callAndTranslateApiException(ApiExceptions.java:57)
                at com.google.api.gax.rpc.UnaryCallable.call(UnaryCallable.java:112)
                at com.google.cloud.apihub.v1.ApiHubClient.updateDeployment(ApiHubClient.java:4053)
                at com.google.cloud.apihub.v1.ApiHubClient.updateDeployment(ApiHubClient.java:4008)
                at com.apigee.apihub.config.mavenplugin.DeploymentsMojo.doUpdate(DeploymentsMojo.java:344)
                at com.apigee.apihub.config.mavenplugin.DeploymentsMojo.processDeployments(DeploymentsMojo.java:211)
                at com.apigee.apihub.config.mavenplugin.DeploymentsMojo.execute(DeploymentsMojo.java:171)
                at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
                at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
                at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
                at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
                at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
                at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
                at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
                at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
                at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
                at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
                at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
                at org.apache.maven.cli.MavenCli.execute(MavenCli.java:972)
                at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:293)
                at org.apache.maven.cli.MavenCli.main(MavenCli.java:196)
                at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
                at java.base/java.lang.reflect.Method.invoke(Method.java:580)
                at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
                at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
                at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
                at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
Caused by: com.google.api.client.http.HttpResponseException: 403 Forbidden
POST https://apihub.googleapis.com:443/v1/projects/PROJECT_ID/locations/LOCATION/deployments/deployment1?$alt=json;enum-encoding%3Dint&updateMask=displayName,description,documentation,deploymentType,resourceUri,endpoints,slo,environment,attributes
{
  "error": {
    "code": 403,
    "message": "Permission denied on resource project PROJECT_ID.",
    "errors": [
      {
        "message": "Permission denied on resource project PROJECT_ID.",
        "domain": "global",
        "reason": "forbidden"
      }
    ],
    "status": "PERMISSION_DENIED",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.Help",
        "links": [
          {
            "description": "Google developers console",
            "url": "https://console.developers.google.com"
          }
        ]
      },
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "CONSUMER_INVALID",
        "domain": "googleapis.com",
        "metadata": {
          "consumer": "projects/PROJECT_ID",
          "service": "apihub.googleapis.com"
        }
      }
    ]
  }
}

        at com.google.api.client.http.HttpResponseException$Builder.build(HttpResponseException.java:293)
        at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1118)
        at com.google.api.gax.httpjson.HttpRequestRunnable.run(HttpRequestRunnable.java:114)
        ... 6 more
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.350 s
[INFO] Finished at: 2024-11-19T00:59:20+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.apigee.apihub.config:apigee-apihub-maven-plugin:1.1.2:deployments (apigee-apihub-deployments) on project apihub: Execution apigee-apihub-deployments of goal com.apigee.apihub.config:apigee-apihub-maven-plugin:1.1.2:deployments failed: Update failure: Forbidden -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException


```  